### PR TITLE
chore: update launch-workflows to 0.14.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+multi-ecosystem-groups:
+  module:
+    schedule:
+      interval: "weekly"
+  workflows:
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    multi-ecosystem-group: "workflows"
+    patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    multi-ecosystem-group: "module"
+    patterns: ["*"]
+
+  - package-ecosystem: "terraform"
+    directory: "/"
+    multi-ecosystem-group: "module"
+    patterns: ["*"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,49 @@
+---
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+template: |
+  # Changelog
+
+  $CHANGES
+
+  ---
+
+  See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION) since previous release.
+
+categories:
+  - title: ":warning: Breaking Changes"
+    labels:
+      - "major"
+  - title: "🚀 Features"
+    labels:
+      - "minor"
+  - title: "🔧 Fixes"
+    collapse-after: 3
+    labels:
+      - "patch"
+
+autolabeler:
+  - label: "major"
+    branch:
+      - '/(patch|bug|fix|feature|feat|chore)!\/.+/'
+  - label: "minor"
+    branch:
+      - '/(feature|feat)\/.+/'
+  - label: "patch"
+    branch:
+      - '/(patch|bug|fix|chore)\/.+/'
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+      - "dependencies"
+  default: patch

--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -1,0 +1,15 @@
+name: Label Pull Request
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check:
+    name: "Label Pull Request"
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@0.14.2
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/pull-request-terraform-check-aws.yml
+++ b/.github/workflows/pull-request-terraform-check-aws.yml
@@ -1,0 +1,22 @@
+name: Check AWS Terraform Code
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check:
+    name: "Check AWS Terraform Code"
+    permissions:
+      contents: read
+      id-token: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-aws.yml@0.14.2
+    with:
+      assume_role_arn: ${{ vars.TERRAFORM_CHECK_AWS_ASSUME_ROLE_ARN }}
+      region: ${{ vars.TERRAFORM_CHECK_AWS_REGION }}
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,18 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  release-on-merge:
+    name: "Create and Publish Release on Merge"
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-release-on-merge.yml@0.14.2
+    secrets: inherit # pragma: allowlist secret

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,9 +1,9 @@
 conftest 0.56.0
-golang 1.22.10
-golangci-lint 1.63.4
-pre-commit 3.3.3
+golang 1.24.2
+golangci-lint 2.10.1
+pre-commit 4.2.0
 regula 3.2.1 # https://github.com/launchbynttdata/asdf-regula
 terraform 1.10.3
-terraform-docs 0.19.0
-terragrunt 0.71.2
-tflint 0.53.0
+terraform-docs 0.20.0
+terragrunt 0.77.22
+tflint 0.57.0

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LCAF_ENV_FILE = .lcafenv
 # Source repository for repo manifests
 REPO_MANIFESTS_URL ?= https://github.com/launchbynttdata/launch-common-automation-framework.git
 # Branch of source repository for repo manifests. Other tags not currently supported.
-REPO_BRANCH ?= refs/tags/1.5.1
+REPO_BRANCH ?= refs/tags/1.8.1
 # Path to seed manifest in repository referenced in REPO_MANIFESTS_URL
 REPO_MANIFEST ?= manifests/terraform_modules/seed/manifest.xml
 


### PR DESCRIPTION
## Summary
- Updated `launch-workflows` reusable workflows at version `0.14.2`
- Added/updated `release-drafter.yml` and `dependabot.yml`

## Files changed
- `A  .github/dependabot.yml`
- `A  .github/release-drafter.yml`
- `A  .github/workflows/pull-request-label.yml`
- `A  .github/workflows/pull-request-terraform-check-aws.yml`
- `A  .github/workflows/release-publish.yml`
- `M  .tool-versions`
- `M  Makefile`

---
Generated by `sync_workflows.py` from [launch-workflows](https://github.com/launchbynttdata/launch-workflows)
